### PR TITLE
Play nicer with NearFuture

### DIFF
--- a/GameData/SquiggsySpaceResearch/Patches/NearFutureAll.cfg
+++ b/GameData/SquiggsySpaceResearch/Patches/NearFutureAll.cfg
@@ -1,5 +1,5 @@
 //Add support for Near Future argon & capacitor
-@PART[microXenon]:NEEDS[NearFuturePropulsion]{
++PART[microXenon]:NEEDS[NearFuturePropulsion]{
   @name = microArgon
   @cost = 62
   @title = Micro Argon Container
@@ -13,7 +13,7 @@
 		maxAmount = 4000
 	}
 }
-@PART[MICROBATSQUARE]:NEEDS[NearFutureElectrical]{
++PART[MICROBATSQUARE]:NEEDS[NearFutureElectrical]{
   @name = microCapacitor
   @cost = 80
   @title = Micro Capacitor


### PR DESCRIPTION
Using `+` rather than `@` creates a new part, rather than editing the existing part. This seems to be the desire, as a new name is provided.

The issue I ran into was I'd created a microsat with a battery, and then installed NearFutureElectrical, and KSP deleted my microsat vessel on loading the game. The above change fixed that.

I haven't tested the Argon Container fix, but I expect it to work the same way.